### PR TITLE
Cleanup after v2. Fix #109

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ node_js:
 - '4'
 env:
   global:
-  - PRODUCTION_BRANCH=publish
+  - PRODUCTION_BRANCH=master
   - STAGING_BRANCH=develop
-  - V2_BRANCH=feature/v2
 cache:
   directories:
   - node_modules
@@ -20,23 +19,12 @@ deploy:
     access_key_id: AKIAIHACHLPCT2PIL4TA
     secret_access_key:
       secure: CHTMZ13ooRXGY0ruRp3mTcg8TMPyM5Ymtg8V7kMmFKPznPMSoQjjHVazuqMTKgP/I5qq6U8S8tTBX/IuhD5MxZJrdBg/ocwpKhgu75xd4SgJsbmpd97jMxX0QU3hA0deDykxYBOKSv9tkZUJRZp8eOlfAjTK6lIKT4cvxGpk3s3VAimLA1e9jGp6vmbXV2GCj0oDBLrkcSrIBBrzClpgM5pmxXDWY1LDhY3vksOKz0GU/btZ8mxdEj3zJ6ZOx9Ny3skMX2eGO0N4JWd/HpEUtPWCp9XdCsXFbH/mQUZcAF5sFUjxsuqPgWkItKt9+TpVCgArhW1E+5DMTnYYPVYMxBhQrL60BaEQ/98rl4KxH+8otvfDlH19f3ESIPbPh0VLGwj9CJ/WQtJ2xhxZmypkfgbD3sGomHpbbSAIHvYSZUcJn34UikBx233JA6jN2ILRr8jvmDaOKg8i3x4aOkrUeMM0n+7alIymuVLlR53wOVifrtQG2xTEiIBkv6cwXyA+MyF3QCEaPOpgzPZLo6Vo+jZgW7XwYvs+TwfbZ9VVuj67E7QuTrwNHKG+CFpJz6SzlMgVJIYD5cwvh+D+py4jfN6+AoXWw4/3I30BzTe01wK2aBuWKHXaxEuj4JoXbACy6eAoTw5ePteAUj6YkK9hSkgByZhbStaeeGjd/ffxMwQ=
-    bucket: openaq-redesign
-    acl: public_read
-    local-dir: dist
-    skip-cleanup: true
-    on:
-      repo: openaq/openaq.github.io
-      branch: ${V2_BRANCH}
-  - provider: s3
-    access_key_id: AKIAIHACHLPCT2PIL4TA
-    secret_access_key:
-      secure: CHTMZ13ooRXGY0ruRp3mTcg8TMPyM5Ymtg8V7kMmFKPznPMSoQjjHVazuqMTKgP/I5qq6U8S8tTBX/IuhD5MxZJrdBg/ocwpKhgu75xd4SgJsbmpd97jMxX0QU3hA0deDykxYBOKSv9tkZUJRZp8eOlfAjTK6lIKT4cvxGpk3s3VAimLA1e9jGp6vmbXV2GCj0oDBLrkcSrIBBrzClpgM5pmxXDWY1LDhY3vksOKz0GU/btZ8mxdEj3zJ6ZOx9Ny3skMX2eGO0N4JWd/HpEUtPWCp9XdCsXFbH/mQUZcAF5sFUjxsuqPgWkItKt9+TpVCgArhW1E+5DMTnYYPVYMxBhQrL60BaEQ/98rl4KxH+8otvfDlH19f3ESIPbPh0VLGwj9CJ/WQtJ2xhxZmypkfgbD3sGomHpbbSAIHvYSZUcJn34UikBx233JA6jN2ILRr8jvmDaOKg8i3x4aOkrUeMM0n+7alIymuVLlR53wOVifrtQG2xTEiIBkv6cwXyA+MyF3QCEaPOpgzPZLo6Vo+jZgW7XwYvs+TwfbZ9VVuj67E7QuTrwNHKG+CFpJz6SzlMgVJIYD5cwvh+D+py4jfN6+AoXWw4/3I30BzTe01wK2aBuWKHXaxEuj4JoXbACy6eAoTw5ePteAUj6YkK9hSkgByZhbStaeeGjd/ffxMwQ=
     bucket: openaq-staging.org
     acl: public_read
     local-dir: dist
     skip-cleanup: true
     on:
-      repo: openaq/openaq.github.io
+      repo: openaq/openaq.org
       branch: ${STAGING_BRANCH}
   - provider: s3
     access_key_id: AKIAIHACHLPCT2PIL4TA
@@ -47,5 +35,5 @@ deploy:
     local-dir: dist
     skip-cleanup: true
     on:
-      repo: openaq/openaq.github.io
+      repo: openaq/openaq.org
       branch: ${PRODUCTION_BRANCH}

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-openaq.org

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015, OpenAQ
+Copyright (c) 2016, OpenAQ
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/app/assets/scripts/config/staging.js
+++ b/app/assets/scripts/config/staging.js
@@ -4,5 +4,6 @@
  */
 
 module.exports = {
-  environment: 'staging'
+  environment: 'staging',
+  api: 'https://api.openaq-staging.org/v1',
 };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "openaq.github.io",
+  "name": "openaq.org",
   "version": "2.0.0",
   "description": "Website for OpenAQ project.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/developmentseed/openaq.github.io.git"
+    "url": "https://github.com/developmentseed/openaq.org"
   },
   "author": {
     "name": "Development Seed",
@@ -12,7 +12,7 @@
   },
   "license": "BSD",
   "bugs": {
-    "url": "https://github.com/developmentseed/openaq.github.io/issues"
+    "url": "https://github.com/developmentseed/openaq.org/issues"
   },
   "homepage": "https://openaq.org",
   "scripts": {


### PR DESCRIPTION
This PR contains the following changes:

- remove obsolete CNAME
- remove v2 from .travis.yml
- have staging site use the staging api
- rename repo in config
- change publish branch to master

---

Before merging this into `develop`, I think we should change the name of the repo to make sure Travis picks it up well.
Once that's working, we can:

- merge into `develop` and check if staging site builds well and is pointing to the correct API
- then merge into `master` and do the same check. I already created a `master` branch from `develop`
- once everything is done, we can remove `publish`

What do you think @jflasher ?