### PR TITLE
More detailed source attribution

### DIFF
--- a/app/assets/scripts/actions/measurements.js
+++ b/app/assets/scripts/actions/measurements.js
@@ -33,7 +33,8 @@ export function fetchMeasurements (location, startDate, endDate) {
     // measurements since ever. This query takes care of that and then we start
     // the actual requests for measurements.
     let totalMeasurements = 0;
-    fetch(`${config.api}/measurements?location=${encodeURIComponent(location)}&limit=1`)
+    let attribution;
+    fetch(`${config.api}/measurements?location=${encodeURIComponent(location)}&include_fields=attribution&limit=1`)
       .then(response => {
         if (response.status >= 400) {
           throw new Error('Bad response');
@@ -42,6 +43,7 @@ export function fetchMeasurements (location, startDate, endDate) {
       })
       .then(json => {
         totalMeasurements = json.meta.found;
+        attribution = json.results.length > 0 ? json.results[0].attribution : null;
         fetcher(1);
       }, e => {
         console.log('e', e);
@@ -76,6 +78,7 @@ export function fetchMeasurements (location, startDate, endDate) {
             return fetcher(++page);
           } else {
             data.meta.totalMeasurements = totalMeasurements;
+            data.attribution = attribution;
             return dispatch(receiveMeasurements(data));
           }
         }, e => {

--- a/app/assets/scripts/views/location.js
+++ b/app/assets/scripts/views/location.js
@@ -240,30 +240,44 @@ var Location = React.createClass({
   },
 
   renderSourceInfo: function () {
+    const {data} = this.props.measurements;
+
     let sources = this.props.loc.data.sourceNames
       .map(o => _.find(this.props.sources, {name: o}))
       .filter(o => o);
 
+    if (data.attribution) {
+      // filtering attribution[0] b/c it kept showing up with same name and url as sources[0]
+      let added = data.attribution.filter((src, index) => index !== 0);
+      sources = [...sources, ...added];
+    }
+
     return (
       <section className='fold fold--filled' id='location-source'>
         <div className='inner'>
-          <header className='fold__header'>
-            <h1 className='fold__title'>Source information</h1>
+          <header className=''>
+            <h5 className='fold__title'>Sources:</h5>
           </header>
           <div className='fold__body'>
+            <div className='col-main'>
             <ul className='sources__list'>
-              {sources.map(source => <li key={source.name}>
-                <div className='col-main'>
-                  <p>Source: <a href={source.sourceURL} title='View source information'>{source.name}</a></p>
-                </div>
-                <div className='col-sec'>
-                  {source.description
-                    ? <p>{source.description}</p>
-                    : null}
-                  For more information contact <a href={`mailto:${source.contacts[0]}`}>{source.contacts[0]}</a>.
-                </div>
-              </li>)}
+              {sources.map(source =>
+                <li key={source.name}>
+                  <p>
+                    {source.sourceURL || source.url
+                      ? <a href={source.sourceURL || source.url}
+                         title='View source information'>
+                         {source.name} </a>
+                      : source.name}
+                  </p>
+                </li>
+              )}
             </ul>
+            </div>
+            <div className='col-sec'>
+              {sources[0].description ? <p>{sources[0].description}</p> : null}
+              For more information contact <a href={`mailto:${sources[0].contacts[0]}`}>{sources[0].contacts[0]}</a>.
+            </div>
           </div>
         </div>
       </section>
@@ -497,7 +511,6 @@ var Location = React.createClass({
         </HeaderMessage>
       );
     }
-
     return (
       <section className='inpage'>
         <header className='inpage__header'>

--- a/app/assets/styles/location/_content.scss
+++ b/app/assets/styles/location/_content.scss
@@ -31,16 +31,23 @@
       margin-bottom: 0;
     }
   }
-  .col-main {
-    @include col(4/12);
-  }
-  .col-sec {
-    @include col(8/12);
-  }
+    @include media(medium-up) {
+    .col-main {
+      padding-right: 1rem;
+      padding-bottom: .5rem;
+      @include col(4/12);
+    }
+    .col-sec {
+      @include col(8/12);
+    }
+}
 
   .sources__list {
     padding: 0;
     list-style: none;
+    li{
+      margin-bottom: .3rem;
+    }
   }
 }
 


### PR DESCRIPTION
This update enables extra attribution sources to be shown in the view for individual locations. It lists the source name, description, and contact info of the original as it did before.  It just adds the source names  and url in the attributions field of the api response in order to list other sources if there are others.  Tweaked app/assets/scripts/actions/measurements to get the attribution info in the api respsone and use it in app/assets/scripts/views/location. Also tweaked the jsx and app/assets/styles/location/_content to show the source names in one column and keep the description and contact info in another as well as add 'Sources:' as a section header.

Glad to look through the code and see if I could chip in.  Hope it helps a bit.  Let me know what you think, if anything needs to change, etc.