### PR TITLE
Bug/footer workshops link

### DIFF
--- a/app/assets/scripts/components/page-footer.js
+++ b/app/assets/scripts/components/page-footer.js
@@ -59,7 +59,7 @@ var PageFooter = React.createClass({
                 <li><Link to='/community' title='View page'>About the community</Link></li>
                 <li><Link to='/community' title='View page'>Data tools</Link></li>
                 <li><Link to='/community/projects' title='View page'>Community impact</Link></li>
-                <li><Link to='/community/projects' title='View page'>Workshops</Link></li>
+                <li><Link to='/community/workshops' title='View page'>Workshops</Link></li>
               </ul>
             </div>
 
@@ -79,11 +79,11 @@ var PageFooter = React.createClass({
               <h2>Subscribe to our newsletter</h2>
               <form ref='newsletterForm' action='//openaq.us10.list-manage.com/subscribe/post?u=ca93b2911fff40db15f6e7203&amp;id=e65a8618a1' method='post' id='mc-embedded-subscribe-form' name='mc-embedded-subscribe-form' target='_blank' noValidate>
                 <div className='form__input-group'>
-                  <input type='email' name='EMAIL' id='mce-EMAIL' placeholder='your@email.com' className='form__control form__control--medium' required/>
+                  <input type='email' name='EMAIL' id='mce-EMAIL' placeholder='your@email.com' className='form__control form__control--medium' required />
                   <span className='form__input-group-button'><button className='button--subscribe' type='submit' onClick={() => this.refs.newsletterForm.reset()}><span>Subscribe</span></button></span>
                 </div>
                 {/* real people should not fill this in and expect good things - do not remove this or risk form bot signups */}
-                <div style={{position: 'absolute', left: '-5000px'}} aria-hidden='true'>
+                <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden='true'>
                   <input type='text' name='b_ca93b2911fff40db15f6e7203_e65a8618a1' tabIndex='-1' value='' />
                 </div>
               </form>

--- a/app/assets/scripts/components/page-footer.js
+++ b/app/assets/scripts/components/page-footer.js
@@ -57,7 +57,7 @@ var PageFooter = React.createClass({
               <h2 className='contact__title'>Community</h2>
               <ul className='foot-menu'>
                 <li><Link to='/community' title='View page'>About the community</Link></li>
-                <li><Link to='/community' title='View page'>Data tools</Link></li>
+                <li><Link to='/community/projects?type=Developer+tools' title='View page'>Data tools</Link></li>
                 <li><Link to='/community/projects' title='View page'>Community impact</Link></li>
                 <li><Link to='/community/workshops' title='View page'>Workshops</Link></li>
               </ul>


### PR DESCRIPTION
While working on https://github.com/openaq/openaq.org/pull/341 I noticed that the workshops link in the footer took me to the projects page.

I've also "fixed" the data tools link, but I could be making an incorrect assumption about where it is supposed to point.

Changes:
Update Community > Workshops link in footer to "/community/workshops"
Update Community > Data tools link in footer to "/community/projects?type=Developer+tools"