### PR TITLE
Use v2 for locations hub

### DIFF
--- a/app/assets/scripts/actions/locations.js
+++ b/app/assets/scripts/actions/locations.js
@@ -30,8 +30,10 @@ export function fetchLocations(page = 1, filters, limit = 15) {
 
     // console.log('url', `${config.api}/locations?page=${page}&limit=${limit}&${f}`);
 
+    console.log(config);
+
     fetch(
-      `${config.api}/locations?page=${page}&limit=${limit}&metadata=true&${f}`
+      `${config.apiv2}/locations?page=${page}&limit=${limit}&metadata=true&${f}`
     )
       .then(response => {
         if (response.status >= 400) {

--- a/app/assets/scripts/actions/locations.js
+++ b/app/assets/scripts/actions/locations.js
@@ -28,10 +28,6 @@ export function fetchLocations(page = 1, filters, limit = 15) {
 
     let f = buildAPIQS(filters, { arrayFormat: 'repeat' });
 
-    // console.log('url', `${config.api}/locations?page=${page}&limit=${limit}&${f}`);
-
-    console.log(config);
-
     fetch(
       `${config.apiv2}/locations?page=${page}&limit=${limit}&metadata=true&${f}`
     )

--- a/app/assets/scripts/components/card/card-details.js
+++ b/app/assets/scripts/components/card/card-details.js
@@ -18,7 +18,7 @@ CardDetails.propTypes = {
   list: T.arrayOf(
     T.shape({
       label: T.string.isRequired,
-      value: T.string.isRequired,
+      value: T.oneOfType([T.string, T.array]).isRequired,
     })
   ).isRequired,
 };

--- a/app/assets/scripts/config/staging.js
+++ b/app/assets/scripts/config/staging.js
@@ -6,5 +6,6 @@
 module.exports = {
   environment: 'staging',
   api: 'https://ytr9800fbk.execute-api.us-east-1.amazonaws.com',
+  apiv2: 'https://ytr9800fbk.execute-api.us-east-1.amazonaws.com/v2',
   metadata: 'https://metadata.openaq-staging.org',
 };

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -174,7 +174,6 @@ Location.propTypes = {
 // Connect functions
 
 function selector(state) {
-  console.log(state);
   return {
     sources: state.baseData.data.sources,
     measurements: state.measurements,

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -174,6 +174,7 @@ Location.propTypes = {
 // Connect functions
 
 function selector(state) {
+  console.log(state);
   return {
     sources: state.baseData.data.sources,
     measurements: state.measurements,

--- a/app/assets/scripts/views/locations-hub/location-card.js
+++ b/app/assets/scripts/views/locations-hub/location-card.js
@@ -63,7 +63,7 @@ export default function LocationCard({
             },
             {
               label: 'Values',
-              value: parametersList.map(p => p.name).join(', '),
+              value: parametersList.map(p => p.measurand).join(', '),
             },
             ...(sources.length ? [{ label: 'Sources', value: sources }] : []),
           ]}
@@ -92,7 +92,7 @@ LocationCard.propTypes = {
   parametersList: T.array,
 
   compact: T.bool,
-  id: T.string,
+  id: T.oneOfType([T.number, T.string]),
   city: T.string,
   countryData: T.object,
   sourcesData: T.array,

--- a/app/assets/scripts/views/locations-hub/results.js
+++ b/app/assets/scripts/views/locations-hub/results.js
@@ -13,8 +13,6 @@ export default function Results({
   error,
   locations,
   countries,
-  sources,
-  parameters,
   totalPages,
   page,
   openDownloadModal,
@@ -69,10 +67,7 @@ export default function Results({
       <div className="inpage__results">
         {locations.map(loc => {
           let countryData = _.find(countries, { code: loc.country });
-          let sourcesData = loc.sourceNames
-            .map(s => _.find(sources, { name: s }))
-            .filter(s => s);
-          let params = loc.parameters.map(o => _.find(parameters, { id: o }));
+          let sourcesData = [loc.sources];
 
           let openModal = () =>
             openDownloadModal({
@@ -84,14 +79,14 @@ export default function Results({
             <LocationCard
               id={loc.id}
               onDownloadClick={openModal}
-              key={loc.location}
-              name={loc.location}
+              key={loc.id}
+              name={loc.name}
               city={loc.city}
               sourceType={loc.sourceType}
               countryData={countryData}
               sourcesData={sourcesData}
-              totalMeasurements={loc.count}
-              parametersList={params}
+              totalMeasurements={loc.measurements}
+              parametersList={loc.parameters}
               lastUpdate={loc.lastUpdated}
               collectionStart={loc.firstUpdated}
             />


### PR DESCRIPTION
Update locations hub to v2. 
After this is merged, locations single page can be pull location data from props rather than requesting again. cc @necoline 