### PR TITLE
Improve table component and add parameter unit

### DIFF
--- a/app/assets/scripts/components/dashboard/measurands-card.js
+++ b/app/assets/scripts/components/dashboard/measurands-card.js
@@ -3,35 +3,31 @@ import { PropTypes as T } from 'prop-types';
 
 import Card from '../card';
 import Table from '../table';
-import { shortenLargeNumber, round } from '../../utils/format';
+import { shortenLargeNumber } from '../../utils/format';
 
-const initData = {
-  parameter: {
-    values: [],
-    formatHeader: v => v.toUpperCase(),
-    style: {
-      color: 'black',
-      fontWeight: 700,
-      textAlign: 'center',
+const tableHeaders = [
+  {
+    id: 'parameter',
+    value: 'Parameter',
+    sortable: true,
+  },
+  {
+    id: 'avg',
+    value: 'Average',
+    sortable: true,
+    formatCell: (value, row) => {
+      return `${shortenLargeNumber(value)} (${row.unit})`;
     },
   },
-  avg: {
-    values: [],
-    formatHeader: v => v.toUpperCase(),
-    formatCell: shortenLargeNumber,
-    style: {
-      textAlign: 'center',
+  {
+    id: 'count',
+    value: 'Count',
+    sortable: true,
+    formatCell: value => {
+      return shortenLargeNumber(value);
     },
   },
-  count: {
-    values: [],
-    formatHeader: v => v.toUpperCase(),
-    formatCell: shortenLargeNumber,
-    style: {
-      textAlign: 'center',
-    },
-  },
-};
+];
 
 /*  TODO This function currently just extracts the first data available for each pollutant
  *  openAQ api returns all available dates averages, or those within a specified date range.
@@ -39,49 +35,21 @@ const initData = {
  *  User specified day? date range? etc
  */
 
-const prepareData = data => {
-  const combinedData = data.reduce((accum, datum) => {
-    const { displayName, count, average } = datum;
-    if (!accum[displayName]) {
-      accum[displayName] = {
-        count: count,
-        value: average,
-      };
-    }
-    return accum;
-  }, {});
-  const preparedData = Object.entries(combinedData).reduce(
-    (acc, [parameter, stats]) => {
-      acc = {
-        parameter: {
-          ...acc.parameter,
-          values: [...acc.parameter.values, parameter],
-        },
-        avg: {
-          ...acc.avg,
-          values: [...acc.avg.values, round(stats.value, 2)],
-        },
-        count: {
-          ...acc.count,
-          values: [...acc.count.values, stats.count],
-        },
-      };
-      return acc;
-    },
-    initData
-  );
-  return preparedData;
-};
-
 export default function MeasureandsCard({ parameters, titleInfo }) {
+  const rows = parameters.map(p => ({
+    parameter: p.displayName,
+    avg: p.average,
+    count: p.count,
+    unit: p.unit,
+  }));
+
   return (
     <Card
       gridColumn={'1 / -1'}
       title="Parameters"
       renderBody={() => {
-        return <Table data={prepareData(parameters)} />;
+        return <Table headers={tableHeaders} rows={rows} />;
       }}
-      noBodyStyle
       titleInfo={titleInfo}
     />
   );

--- a/app/assets/scripts/components/table.js
+++ b/app/assets/scripts/components/table.js
@@ -1,163 +1,117 @@
 import React, { useState } from 'react';
-import styled, { css } from 'styled-components';
 import T from 'prop-types';
+import c from 'classnames';
+import _ from 'lodash';
 
-/*
+/**
  * Table component
- * @param data - data object used to construct table
- *    expected in the following format:
- *    {
- *      header1: {
- *        values: [Array](required),
+ * @param headers - table headers expected in the following format:
+ *    [
+ *      {
+ *        id: [String](required) // header1
  *        formatCell: [function](optional),
  *        formatHeader: [function])(optional),
  *        sortable: [boolean](optional, default false),
- *        cellWidth: [string](optional)
  *      },
  *      ...,
- *      headerN: {
- *        values: [Array](required),
+ *      {
+ *        id: [String](required) // headerN
  *        formatCell: [function](optional),
  *        formatHeader: [function])(optional),
  *        sortable: [boolean](optional, default false),
- *        cellWidth: [string](optional)
  *      }
+ *    ]
+ * @param rows - Data for the table body. If the header formatCell functions are
+ * not used it must have the value under the header id.
+ *   [
+ *    {
+ *     header1: something
+ *     headerN: something-else
  *    }
+ *   ]
  */
-const Table = styled.table``;
-const Row = styled.tr`
-  ${({ header }) =>
-    header &&
-    css`
-      background-color: #f8f8f8;
-    `}
-  th:first-child {
-    border-left: none;
-  }
-  th:last-child {
-    border-right: none;
-  }
-`;
-const Header = styled.th`
-  max-width: 5rem;
-  padding: 0.75rem 1rem;
-  text-align: center;
-  border-left: 1px solid #e1e1e1;
-  border-right: 1px solid #e1e1e1;
-  border-collapse: collapse;
-  font-weight: 500;
-  font-size: 0.7rem;
-  ${({ active }) =>
-    active &&
-    css`
-      font-weight: 900;
-    `}
-
-  &:hover {
-    transform: scale(1.05);
-  }
-`;
-const Cell = styled.td`
-  padding: 0.75rem 1.5rem;
-
-  ${({ style }) =>
-    style &&
-    css`
-      ${Object.entries(style)
-        .map(([key, value]) => `${key}: ${value};`)
-        .join('\n')}
-    `}
-`;
-
-const prepareRows = data => {
-  const numVals = Math.max(
-    ...Object.values(data).map(datum => datum.values.length)
-  );
-  const rows = [];
-  for (let i = 0; i < numVals; i++) {
-    rows.push(
-      Object.entries(data).map(([key, column]) => {
-        return {
-          header: key,
-          value: column.values[i],
-          formatCell: column.formatCell,
-          style: column.style,
-        };
-      })
-    );
-  }
-  return rows;
-};
 function TableComponent(props) {
-  const { data } = props;
-  const [activeHeader, setActiveHeader] = useState(null);
+  const { headers, rows } = props;
+  const [activeHeader, setActiveHeader] = useState(headers[0].id);
   const [sortAsc, setSortAsc] = useState(true);
+
+  const sortedRows = _(rows)
+    .sortBy(activeHeader)
+    .tap(array => {
+      if (!sortAsc) _.reverse(array);
+    })
+    .value();
+
   return (
-    <Table className="global-table">
+    <table className="table table--zebra">
       <thead>
-        <Row header>
-          {Object.entries(data).map(([key, datum]) => {
-            const { formatHeader } = datum;
-            return (
-              <Header
-                className={`sort_${sortAsc ? 'asc' : 'desc'}`}
-                key={key}
-                active={key === activeHeader}
-                onClick={() => {
-                  setActiveHeader(key);
-                  setSortAsc(!sortAsc);
-                }}
-              >
-                {formatHeader ? formatHeader(key) : key}
-              </Header>
-            );
+        <tr>
+          {headers.map((header, idx) => {
+            const { sortable, id, formatHeader, value } = header;
+            const headerValue =
+              typeof formatHeader === 'function'
+                ? formatHeader(header, idx)
+                : value;
+
+            if (sortable) {
+              const onClick = e => {
+                e.preventDefault();
+                if (activeHeader === id) {
+                  setSortAsc(v => !v);
+                } else {
+                  setActiveHeader(id);
+                  setSortAsc(true);
+                }
+              };
+              const classes = c('table__sort', {
+                'table__sort--none': activeHeader !== id,
+                'table__sort--asc': activeHeader === id && sortAsc,
+                'table__sort--desc': activeHeader === id && !sortAsc,
+              });
+
+              return (
+                <th key={id}>
+                  <a
+                    className={classes}
+                    href="#"
+                    title="Sort table by field"
+                    onClick={onClick}
+                  >
+                    {headerValue}
+                  </a>
+                </th>
+              );
+            } else {
+              return <th key={id}>{headerValue}</th>;
+            }
           })}
-        </Row>
+        </tr>
       </thead>
       <tbody>
-        {prepareRows(data)
-          .sort((rowA, rowB) => {
-            if (!activeHeader) {
-              return 0;
-            }
-            const valA = rowA.find(el => el.header === activeHeader).value;
-            const valB = rowB.find(el => el.header === activeHeader).value;
+        {sortedRows.map((row, idx) => {
+          return (
+            <tr key={`sort-${activeHeader}-${sortAsc}-${idx}`}>
+              {headers.map(header => {
+                const { id, formatCell } = header;
 
-            const dir = sortAsc ? 1 : -1;
+                const cellValue =
+                  typeof formatCell === 'function'
+                    ? formatCell(row[id], row, header)
+                    : row[id];
 
-            if (valA > valB) {
-              return 1 * dir;
-            } else if (valA < valB) {
-              return -1 * dir;
-            } else {
-              return 0;
-            }
-          })
-          .map((row, i) => {
-            return (
-              <Row key={`row-${i}`} index={i}>
-                {row.map(cell => {
-                  return (
-                    <Cell
-                      style={cell.style}
-                      key={`${cell.header}-${cell.value}`}
-                    >
-                      {cell.formatCell
-                        ? cell.formatCell(cell.value)
-                        : cell.value}
-                    </Cell>
-                  );
-                })}
-              </Row>
-            );
-          })}
+                return <td key={id}>{cellValue}</td>;
+              })}
+            </tr>
+          );
+        })}
       </tbody>
-    </Table>
+    </table>
   );
 }
 
 TableComponent.propTypes = {
-  data: T.object,
+  headers: T.array,
+  rows: T.array,
 };
 
 export default TableComponent;

--- a/app/assets/scripts/utils/format.js
+++ b/app/assets/scripts/utils/format.js
@@ -44,7 +44,7 @@ export function shortenLargeNumber(value, decimals = 2) {
     value = round(value / 1e6, decimals) + 'M';
   } else if (value / 1e3 >= 1) {
     value = round(value / 1e3, decimals) + 'k';
-  } else if (value < 1) {
+  } else {
     value = round(value, decimals);
   }
   return value;


### PR DESCRIPTION
While looking at adding the parameter unit (#513 ) to the table I came across some problems which were complicating the task. Given that the table was not being used anywhere else I refactored it.

- The table had a mix-and-match of styles, some coming from styled components, other being added as properties. The openaq-design-system has styles for tables which are more in sync with the rest of the site. I used these instead.
- The sort was not working properly. It was being done on the rendered value which is a string. This leads to the wrong order when ordering numbers.
- Adding the unit as part of the value would just compound the problem above. The new behavior is to sort by a raw value (the number) and then render a display value.