### PR TITLE
Update map symbolization

### DIFF
--- a/app/assets/scripts/components/map/legend.js
+++ b/app/assets/scripts/components/map/legend.js
@@ -108,12 +108,12 @@ export default function Legend({
           <dt>
             <Circle />
           </dt>
-          <dd>Government Data stations</dd>
+          <dd>Reference grade sensor</dd>
 
           <dt>
             <Square />
           </dt>
-          <dd>Low Cost Sensor Stations</dd>
+          <dd>Low Cost Sensor</dd>
         </Definition>
       </Container>
       <Container>

--- a/app/assets/scripts/components/map/legend.js
+++ b/app/assets/scripts/components/map/legend.js
@@ -2,8 +2,59 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'openaq-design-system';
 import c from 'classnames';
+import styled from 'styled-components';
 
 import { generateLegendStops } from '../../utils/colors';
+
+const Wrapper = styled.div`
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  right: 1rem;
+  z-index: 20;
+  max-width: 24rem;
+  overflow: hidden;
+
+  box-shadow: 0 0 32px 2px rgba(35, 47, 59, 0.04),
+    0 16px 48px -16px rgba(35, 47, 59, 0.12);
+  background-color: rgba(35, 47, 59, 0.04);
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @media only screen and (min-width: 768px) {
+    bottom: 2rem;
+    left: 2rem;
+  }
+`;
+
+const Container = styled.div`
+  padding: 1.5rem;
+  background: #fff;
+`;
+
+const Definition = styled.dl`
+  margin: 0;
+  & > dd {
+    margin: 0;
+  }
+  display: grid;
+  grid-template-columns: 15px auto;
+  gap: 0.75rem;
+  align-items: center;
+  text-transform: uppercase;
+`;
+
+const Square = styled.div`
+  width: 15px;
+  height: 15px;
+  background-color: #198cff;
+`;
+
+const Circle = styled(Square)`
+  border-radius: 50%;
+`;
 
 export default function Legend({
   parameters,
@@ -51,8 +102,21 @@ export default function Legend({
   const colorWidth = 100 / scaleStops.length;
 
   return (
-    <div className="map__legend">
-      <div>
+    <Wrapper>
+      <Container>
+        <Definition>
+          <dt>
+            <Circle />
+          </dt>
+          <dd>Government Data stations</dd>
+
+          <dt>
+            <Square />
+          </dt>
+          <dd>Low Cost Sensor Stations</dd>
+        </Definition>
+      </Container>
+      <Container>
         <p>
           Showing the most recent values for{' '}
           {parameters.length > 1 ? drop : activeParameter.displayName}
@@ -73,8 +137,8 @@ export default function Legend({
             Data Disclaimer and More Information
           </a>
         </small>
-      </div>
-    </div>
+      </Container>
+    </Wrapper>
   );
 }
 

--- a/app/assets/scripts/utils/map-settings.js
+++ b/app/assets/scripts/utils/map-settings.js
@@ -45,6 +45,15 @@ export const borderCircleRadius = {
   ],
 };
 
+// Border for all squares
+export const borderSquareSize = {
+  stops: [
+    [0, 0.5],
+    [5, 0.7],
+    [7, 1.4],
+  ],
+};
+
 // Border Radius for the white outline around selected points
 export const selectCircleRadius = {
   stops: [

--- a/app/assets/scripts/utils/map-settings.js
+++ b/app/assets/scripts/utils/map-settings.js
@@ -26,6 +26,15 @@ export const coloredCircleRadius = {
   ],
 };
 
+// Fill Radius for all station points w/ values
+export const coloredSquareSize = {
+  stops: [
+    [0, 0.3],
+    [5, 0.5],
+    [7, 1.2],
+  ],
+};
+
 // Border Radius for all points
 export const borderCircleRadius = {
   stops: [


### PR DESCRIPTION
Contribute to #472 

This is splitting the measurements layer into two symbols, squared and circled.
I am using an `Uint8Array` to create the square and I am not sure why this needs an initial color, it is going to be repainted anyways just like the circles. It would be cool to use something like [this approach](https://stackoverflow.com/a/30585171/1937860) to draw the circles in the same way as squared, just with transparent corners. We could re-use the same layer that way, just referring to another image based on the property.

Currently, I only have a `isMobile` property available on the vector tiles. @bitner , could you add something to differentiate 	      'Low Cost Sensor' vs. 'Reference-Grade'? I need to revise language in the symbol legend as well, can you help @rwegener2 ?