### PR TITLE
Grey out old measurements on map

### DIFF
--- a/app/assets/scripts/components/map/legend.js
+++ b/app/assets/scripts/components/map/legend.js
@@ -118,7 +118,7 @@ export default function Legend({
       </Container>
       <Container>
         <p>
-          Showing the most recent values for{' '}
+          Showing the most recent* values for{' '}
           {parameters.length > 1 ? drop : activeParameter.displayName}
         </p>
         <ul className="color-scale">
@@ -132,6 +132,7 @@ export default function Legend({
             </li>
           ))}
         </ul>
+        <p>* Locations not updated in the last week are shown in grey.</p>
         <small className="disclaimer">
           <a href="https://medium.com/@openaq/where-does-openaq-data-come-from-a5cf9f3a5c85">
             Data Disclaimer and More Information

--- a/app/assets/scripts/components/map/measurements-layer.js
+++ b/app/assets/scripts/components/map/measurements-layer.js
@@ -170,7 +170,7 @@ export default function MeasurementsLayer({
   }, [sourceId, activeParameter]);
 
   useEffect(() => {
-    const openPopup = function (e) {
+    const openPopup = e => {
       const coordinates = e.features[0].geometry.coordinates.slice();
 
       // Ensure that if the map is zoomed out such that multiple

--- a/app/assets/scripts/components/map/measurements-layer.js
+++ b/app/assets/scripts/components/map/measurements-layer.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { useRouteMatch } from 'react-router-dom';
 import mapbox from 'mapbox-gl';
-import moment from 'moment';
 
 import {
   circleOpacity,
@@ -13,11 +12,7 @@ import {
   coloredSquareSize,
   borderSquareSize,
 } from '../../utils/map-settings';
-import {
-  generateColorStops,
-  unusedColor,
-  unusedBorderColor,
-} from '../../utils/colors';
+import { getFillExpression } from '../../utils/colors';
 import Popover from './popover';
 
 const square = {
@@ -66,19 +61,6 @@ export default function MeasurementsLayer({
   const circlesLocationIdFilter = ['all', locationIdFilter, circlesFilter];
   const squaresLocationIdFilter = ['all', locationIdFilter, squaresFilter];
 
-  const weekAgo = moment().subtract(7, 'days').toISOString();
-  const fillExpression = isDark => [
-    'case',
-    ['>', ['get', 'lastUpdated'], ['literal', weekAgo]],
-    [
-      'interpolate',
-      ['linear'],
-      ['number', ['get', 'lastValue']],
-      ...generateColorStops(activeParameter, isDark).flat(),
-    ],
-    isDark ? unusedBorderColor : unusedColor,
-  ];
-
   useEffect(() => {
     if (!map.hasImage('square')) map.addImage('square', square, { sdf: true });
     map.addLayer({
@@ -87,7 +69,7 @@ export default function MeasurementsLayer({
       'source-layer': 'default',
       type: 'symbol',
       paint: {
-        'icon-color': fillExpression('dark'),
+        'icon-color': getFillExpression(activeParameter, 'dark'),
       },
       layout: {
         'icon-image': 'square',
@@ -103,7 +85,7 @@ export default function MeasurementsLayer({
       'source-layer': 'default',
       type: 'symbol',
       paint: {
-        'icon-color': fillExpression(),
+        'icon-color': getFillExpression(activeParameter),
       },
       layout: {
         'icon-image': 'square',
@@ -119,7 +101,7 @@ export default function MeasurementsLayer({
       'source-layer': 'default',
       type: 'circle',
       paint: {
-        'circle-color': fillExpression('dark'),
+        'circle-color': getFillExpression(activeParameter, 'dark'),
         'circle-opacity': 1,
         'circle-radius': borderCircleRadius,
         'circle-blur': 0,
@@ -133,7 +115,7 @@ export default function MeasurementsLayer({
       'source-layer': 'default',
       type: 'circle',
       paint: {
-        'circle-color': fillExpression(),
+        'circle-color': getFillExpression(activeParameter),
         'circle-opacity': circleOpacity,
         'circle-radius': coloredCircleRadius,
         'circle-blur': circleBlur,

--- a/app/assets/scripts/components/map/measurements-layer.js
+++ b/app/assets/scripts/components/map/measurements-layer.js
@@ -145,9 +145,15 @@ export default function MeasurementsLayer({
     map.on('mouseenter', `${activeParameter}-circles`, function () {
       map.getCanvas().style.cursor = 'pointer';
     });
+    map.on('mouseenter', `${activeParameter}-squares`, function () {
+      map.getCanvas().style.cursor = 'pointer';
+    });
 
     // Change it back to a pointer when it leaves.
     map.on('mouseleave', `${activeParameter}-circles`, function () {
+      map.getCanvas().style.cursor = '';
+    });
+    map.on('mouseleave', `${activeParameter}-squares`, function () {
       map.getCanvas().style.cursor = '';
     });
 

--- a/app/assets/scripts/components/map/mobile-layer.js
+++ b/app/assets/scripts/components/map/mobile-layer.js
@@ -1,15 +1,9 @@
-import React, { useEffect } from 'react';
-import ReactDOM from 'react-dom';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useRouteMatch } from 'react-router-dom';
-import mapbox from 'mapbox-gl';
 
-import Popover from './popover';
 import { unusedBorderColor } from '../../utils/colors';
 
-export default function MobileLayer({ map, sourceId }) {
-  let match = useRouteMatch();
-
+export default function MobileLayer({ activeParameter, map, sourceId }) {
   useEffect(() => {
     map.addLayer({
       id: 'mobile-layer',
@@ -18,54 +12,23 @@ export default function MobileLayer({ map, sourceId }) {
       type: 'line',
       paint: {
         'line-color': unusedBorderColor,
+        // to add once properties are included in vectore tiles
+        // 'line-color': getFillExpression(activeParameter),
         'line-width': 5,
         'line-opacity': 0.6,
       },
     });
 
-    map.on('click', 'mobile-layer', function (e) {
-      const coordinates = e.features[0].geometry.coordinates.slice();
-
-      // Ensure that if the map is zoomed out such that multiple
-      // copies of the feature are visible, the popup appears
-      // over the copy being pointed to.
-      while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
-        coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
-      }
-
-      let popoverElement = document.createElement('div');
-      ReactDOM.render(
-        <Popover
-          locationId={e.features[0].properties.locationId}
-          currentPage={parseInt(match.params.id, 10)}
-        />,
-        popoverElement
-      );
-      new mapbox.Popup()
-        .setLngLat(coordinates)
-        .setDOMContent(popoverElement)
-        .addTo(map);
-    });
-
-    // Change the cursor to a pointer when the mouse is over the layer.
-    map.on('mouseenter', 'mobile-layer', function () {
-      map.getCanvas().style.cursor = 'pointer';
-    });
-
-    // Change it back to a pointer when it leaves.
-    map.on('mouseleave', 'mobile-layer', function () {
-      map.getCanvas().style.cursor = '';
-    });
-
     return () => {
       if (map.getLayer('mobile-layer')) map.removeLayer('mobile-layer');
     };
-  }, []);
+  }, [activeParameter]);
 
   return null;
 }
 
 MobileLayer.propTypes = {
+  activeParameter: PropTypes.string,
   map: PropTypes.object,
   sourceId: PropTypes.string,
 };

--- a/app/assets/scripts/utils/colors.js
+++ b/app/assets/scripts/utils/colors.js
@@ -2,6 +2,7 @@ var d3 = require('d3');
 var chroma = require('chroma-js');
 import { parameterMax, parameterUnit } from './map-settings';
 import { round } from '../utils/format';
+import moment from 'moment';
 
 // Colors for the legend and point fills
 const mapColors = [
@@ -100,4 +101,20 @@ export function generateLegendStops(parameter) {
   stops[stops.length - 1].label += '+';
 
   return stops;
+}
+
+const weekAgo = moment().subtract(7, 'days').toISOString();
+
+export function getFillExpression(parameter, isDark) {
+  return [
+    'case',
+    ['>', ['get', 'lastUpdated'], ['literal', weekAgo]],
+    [
+      'interpolate',
+      ['linear'],
+      ['number', ['get', 'lastValue']],
+      ...generateColorStops(parameter, isDark).flat(),
+    ],
+    isDark ? unusedBorderColor : unusedColor,
+  ];
 }

--- a/app/assets/scripts/views/world-map.js
+++ b/app/assets/scripts/views/world-map.js
@@ -120,7 +120,7 @@ function WorldMap({ location, history }) {
       <div className="inpage__body">
         <MapComponent>
           <LocationsSource activeParameter={activeParameter.name}>
-            <MobileLayer />
+            <MobileLayer activeParameter={activeParameter.id} />
             <MeasurementsLayer activeParameter={activeParameter.id} />
           </LocationsSource>
           <Legend


### PR DESCRIPTION
Close #472 

Locations that are older than 1 week are greyed out on the map, as discussed in https://github.com/openaq/openaq.org/issues/472#issuecomment-756158236.
Also adding small fixes for cursor styling on clickable layers and popup.