### PR TITLE
Fix tiles request

### DIFF
--- a/app/assets/scripts/views/world-map.js
+++ b/app/assets/scripts/views/world-map.js
@@ -119,7 +119,7 @@ function WorldMap({ location, history }) {
       </header>
       <div className="inpage__body">
         <MapComponent>
-          <LocationsSource activeParameter={activeParameter.name}>
+          <LocationsSource activeParameter={activeParameter.id}>
             <MobileLayer activeParameter={activeParameter.id} />
             <MeasurementsLayer activeParameter={activeParameter.id} />
           </LocationsSource>

--- a/app/assets/scripts/views/world-map.js
+++ b/app/assets/scripts/views/world-map.js
@@ -105,7 +105,7 @@ function WorldMap({ location, history }) {
   const queryParameter = qs.parse(location.search, { ignoreQueryPrefix: true })
     .parameter;
   const activeParameter = _.find(parameters, {
-    id: Number(queryParameter) || 7,
+    id: Number(queryParameter) || 2,
   });
 
   return (


### PR DESCRIPTION
Using parameter id instead of name to request tiles. Also changing the default parameter to be pm2.5 (as it was in previous versions)