### PR TITLE
Small fixes for country page

### DIFF
--- a/app/assets/scripts/components/map/map.js
+++ b/app/assets/scripts/components/map/map.js
@@ -4,7 +4,7 @@ import mapbox from 'mapbox-gl';
 
 import config from '../../config';
 
-export default function Map({ center, bbox, children }) {
+export default function Map({ center, bbox, scrollZoomDisabled, children }) {
   const containerRef = useRef();
 
   const [map, setMap] = useState(null);
@@ -19,6 +19,8 @@ export default function Map({ center, bbox, children }) {
     });
 
     m.addControl(new mapbox.NavigationControl());
+
+    if (scrollZoomDisabled) m.scrollZoom.disable();
 
     m.on('load', () => {
       setMap(m);
@@ -60,6 +62,7 @@ export default function Map({ center, bbox, children }) {
 Map.propTypes = {
   center: PropTypes.arrayOf(PropTypes.number),
   bbox: PropTypes.arrayOf(PropTypes.number),
+  scrollZoomDisabled: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),

--- a/app/assets/scripts/components/map/measurements-layer.js
+++ b/app/assets/scripts/components/map/measurements-layer.js
@@ -24,7 +24,7 @@ export default function MeasurementsLayer({
 }) {
   let match = useRouteMatch();
 
-  const countryFilter = ['==', 'country', country];
+  const countryFilter = ['==', ['get', 'country'], country];
   const circlesFilter = ['==', ['get', 'isMobile'], false];
   const squaresFilter = ['==', ['get', 'isMobile'], true];
 

--- a/app/assets/scripts/views/country/country.js
+++ b/app/assets/scripts/views/country/country.js
@@ -142,7 +142,9 @@ function Country(props) {
             tagline="Country"
             title={country.name}
             stats={[
-              { number: country.cities, label: 'areas' },
+              ...(country.cities
+                ? [{ number: country.cities, label: 'areas' }]
+                : []),
               {
                 number: country.locations,
                 label: country.locations > 1 ? 'locations' : 'location',

--- a/app/assets/scripts/views/country/country.js
+++ b/app/assets/scripts/views/country/country.js
@@ -169,7 +169,10 @@ function Country(props) {
           <div className="inpage__body">
             <section className="fold" id="country-fold-map">
               <div className="fold__body">
-                <MapComponent bbox={getCountryBbox(country.code)}>
+                <MapComponent
+                  bbox={getCountryBbox(country.code)}
+                  scrollZoomDisabled
+                >
                   <LocationsSource activeParameter={2}>
                     <MeasurementsLayer
                       activeParameter={2}

--- a/cypress/integration/country.spec.js
+++ b/cypress/integration/country.spec.js
@@ -26,7 +26,6 @@ describe('The Country Page', () => {
     cy.get('[data-cy=country-header-title').contains('Cyprus');
 
     cy.get('[data-cy=country-header-stats').should('exist');
-    cy.get('[data-cy=country-header-stat-areas').should('exist');
     cy.get('[data-cy=country-header-stat-locations').should('exist');
     cy.get('[data-cy=country-header-stat-measurements').should('exist');
     cy.get('[data-cy=country-header-stat-source').should('exist');


### PR DESCRIPTION
Contribute to #543 

- Filter needs to be updated to be compatible with ["all", ...]
- Skip areas label in country page header when the number is not available
- Disable scroll zoom on country map (It is still possible to zoom with buttons!)