### PR TITLE
Update stats component to use summary endpoint

### DIFF
--- a/app/assets/scripts/views/home/stats-count.js
+++ b/app/assets/scripts/views/home/stats-count.js
@@ -20,8 +20,7 @@ export default function StatsCount() {
     const fetchData = () => {
       setState(state => ({ ...state, fetching: true, error: null }));
 
-      // TODO: replace with stats endpoint
-      fetch(`${config.api}/locations`)
+      fetch(`${config.api}/summary`)
         .then(response => {
           if (response.status >= 400) {
             throw new Error('Bad response');
@@ -34,7 +33,7 @@ export default function StatsCount() {
               ...state,
               fetched: true,
               fetching: false,
-              data: { locations: json.meta.found },
+              data: json.results[0],
             }));
           },
           e => {
@@ -133,17 +132,17 @@ export default function StatsCount() {
         <figure className="fold__media">
           {!fetching ? (
             <ol className="big-stats-list">
-              {data.totalMeasurements && (
+              {data?.count && (
                 <li className="big-stat">
                   <strong className="big-stat__value">
-                    {shortenLargeNumber(data.totalMeasurements, 0)}
+                    {shortenLargeNumber(data.count, 0)}
                   </strong>
                   <span className="big-stat__label">
                     Air quality measurements
                   </span>
                 </li>
               )}
-              {data.sources && (
+              {data?.sources && (
                 <li className="big-stat">
                   <strong className="big-stat__value">
                     {shortenLargeNumber(data.sources, 0)}
@@ -151,7 +150,7 @@ export default function StatsCount() {
                   <span className="big-stat__label">Data sources</span>
                 </li>
               )}
-              {data.locations && (
+              {data?.locations && (
                 <li className="big-stat">
                   <strong className="big-stat__value">
                     {shortenLargeNumber(data.locations, 0)}
@@ -159,7 +158,7 @@ export default function StatsCount() {
                   <span className="big-stat__label">Locations</span>
                 </li>
               )}
-              {data.countries && (
+              {data?.countries && (
                 <li className="big-stat">
                   <strong className="big-stat__value">
                     {shortenLargeNumber(data.countries, 0)}

--- a/cypress/integration/country.spec.js
+++ b/cypress/integration/country.spec.js
@@ -19,7 +19,7 @@ describe('The Country Page', () => {
     cy.get('[data-cy=country-header-stats').should('exist');
     cy.get('[data-cy=country-header-stat-locations').should('exist');
     cy.get('[data-cy=country-header-stat-measurements').should('exist');
-    cy.get('[data-cy=country-header-stat-source').should('exist');
+    cy.get('[data-cy=country-header-stat-sources').should('exist');
 
     // tests that the link should open in a new tab
     cy.get('[data-cy=header-apidocs-btn').should(


### PR DESCRIPTION
Changed the endpoint used in the stats component to use the new summary endpoint. I get `Failed to fetch` though, while I do get a valid response hitting the api directly 🤔 Any ideas, why?

UPDATE: it works now. probably an api hiccup, or cors not enabled