### PR TITLE
Add/572 datasets filters

### DIFF
--- a/app/assets/scripts/views/projects-hub/project-card.js
+++ b/app/assets/scripts/views/projects-hub/project-card.js
@@ -17,6 +17,8 @@ export default function ProjectCard({
   totalMeasurements,
   parametersList,
   sources,
+  sensorType, entity,
+  mobile
 }) {
   let updated = moment(lastUpdated).fromNow();
   let started = moment(firstUpdated).format('YYYY/MM/DD');
@@ -35,7 +37,8 @@ export default function ProjectCard({
           Updated <strong>{updated}</strong>
         </>
       }
-      tags={sourceType}
+      tags={[sensorType, entity, mobile ? 'Mobile' : 'Stationary']}
+
       renderBody={() => (
         <CardDetails
           id="project"

--- a/app/assets/scripts/views/projects-hub/project-card.js
+++ b/app/assets/scripts/views/projects-hub/project-card.js
@@ -11,14 +11,14 @@ export default function ProjectCard({
   id,
   name,
   subtitle,
-  sourceType,
   firstUpdated,
   totalLocations,
   totalMeasurements,
   parametersList,
   sources,
-  sensorType, entity,
-  mobile
+  sensorType,
+  entity,
+  mobile,
 }) {
   let updated = moment(lastUpdated).fromNow();
   let started = moment(firstUpdated).format('YYYY/MM/DD');
@@ -38,7 +38,6 @@ export default function ProjectCard({
         </>
       }
       tags={[sensorType, entity, mobile ? 'Mobile' : 'Stationary']}
-
       renderBody={() => (
         <CardDetails
           id="project"
@@ -85,7 +84,9 @@ ProjectCard.propTypes = {
   name: T.string,
   id: T.oneOfType([T.string, T.number]),
   subtitle: T.string,
-  sourceType: T.oneOfType([T.array, T.string]),
+  sensorType: T.string,
+  entity: T.string,
+  mobile: T.bool,
   sources: T.array,
   firstUpdated: T.string,
   totalLocations: T.number,

--- a/app/assets/scripts/views/projects-hub/projects-hub.js
+++ b/app/assets/scripts/views/projects-hub/projects-hub.js
@@ -90,7 +90,10 @@ export default function ProjectsHub({
       <HubHeader title="Dataset" countriesCount={countryCount} />
 
       <div className="inpage__body">
-        <Filter slug="/projects" by={['parameters', 'countries', 'sensor']} />
+        <Filter
+          slug="/projects"
+          by={['parameters', 'countries', 'sources', 'sensor']}
+        />
         <div className="constrainer">
           <div className="content__meta">
             <div className="content__header">

--- a/app/assets/scripts/views/projects-hub/projects-hub.js
+++ b/app/assets/scripts/views/projects-hub/projects-hub.js
@@ -54,7 +54,12 @@ export default function ProjectsHub({
       sort: 'desc',
       parameter: query.parameters && query.parameters.split(','),
       country: query.countries && query.countries.split(','),
-      source: query.sources && query.sources.split(','),
+      sourceName: query.sources && query.sources.split(','),
+      // The following are not lists
+      isMobile: query.mobility && query.mobility === 'Mobile',
+      entity: query.entity && query.entity.toLowerCase(),
+      sensorType: query.grade && query.grade.toLowerCase(),
+      manufacturerName: query.manufacturer && query.manufacturer,
     });
   }, [location]);
 
@@ -85,7 +90,7 @@ export default function ProjectsHub({
       <HubHeader title="Dataset" countriesCount={countryCount} />
 
       <div className="inpage__body">
-        <Filter slug="/projects" by={['parameters', 'countries']} />
+        <Filter slug="/projects" by={['parameters', 'countries', 'sensor']} />
         <div className="constrainer">
           <div className="content__meta">
             <div className="content__header">

--- a/app/assets/scripts/views/projects-hub/results.js
+++ b/app/assets/scripts/views/projects-hub/results.js
@@ -83,6 +83,9 @@ export default function Results({
               totalLocations={project.locations}
               totalMeasurements={project.measurements}
               parametersList={project.parameters}
+              mobile={project.isMobile}
+              sensorType={project.sensorType}
+              entity={project.entity}
             />
           );
         })}


### PR DESCRIPTION
closes #572 
Also adds tags to project cards 


Sensor type query is not working currently.  projects endpoint seems to expect boolean values for entity and sensorType as opposed to locations which takes string. Needs clarification re: is this a bug or not