### PR TITLE
Specify environment in deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,21 +4,25 @@ name: Production Deploy
 
 on:
   push:
-    branches: 
+    branches:
       - master
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
+
+    env:
+      DS_ENV: 'production'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Use Node.js 10
         uses: actions/setup-node@v1
         with:
           node-version: 10
-      
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -30,13 +34,13 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-            
+
       - name: Install
         run: npm install
-        
+
       - name: Build
         run: npm run build
-        
+
       - name: Deploy 🚀
         uses: jakejarvis/s3-sync-action@master
         with:
@@ -45,5 +49,5 @@ jobs:
           AWS_S3_BUCKET: 'openaq.org'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-1"
-          SOURCE_DIR: "dist"
+          AWS_REGION: 'us-east-1'
+          SOURCE_DIR: 'dist'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,24 +4,28 @@ name: Staging Deploy
 
 on:
   workflow_run:
-    workflows: ["QA"]
+    workflows: ['QA']
     types:
       - completed
-    branches: [develop] 
+    branches: [develop]
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    env:
+      DS_ENV: 'staging'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Use Node.js 10
         uses: actions/setup-node@v1
         with:
           node-version: 10
-      
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -33,13 +37,13 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-            
+
       - name: Install
         run: npm install
-        
+
       - name: Build
         run: npm run build
-        
+
       - name: Deploy 🚀
         uses: jakejarvis/s3-sync-action@master
         with:
@@ -48,5 +52,5 @@ jobs:
           AWS_S3_BUCKET: 'openaq-staging.org'
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: "us-east-1"
-          SOURCE_DIR: "dist"
+          AWS_REGION: 'us-east-1'
+          SOURCE_DIR: 'dist'


### PR DESCRIPTION
Our current production environment is not pointing to the expected endpoints. It seems to be an issue related with the config setup, see [here](https://github.com/openaq/openaq.org/blob/develop/gulpfile.js#L43). I am assuming we don't have the TRAVIS_BRANCH env var anymore after switching to github actions, and setting the DS_ENV explicitly will fix the issue. @danielfdsilva can you confirm this would work as I expect?