### PR TITLE
Add locationIds to mobile layers to filter by

### DIFF
--- a/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
+++ b/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
@@ -47,8 +47,14 @@ export default function MobileDataLocationsCard({
               firstUpdated={firstUpdated}
               lastUpdated={lastUpdated}
             >
-              <MobileBoundsLayer locationId={locationId} />
-              <MobilePointsLayer locationId={locationId} />
+              <MobileBoundsLayer
+                locationId={locationId}
+                locationIds={locationIds}
+              />
+              <MobilePointsLayer
+                locationId={locationId}
+                locationIds={locationIds}
+              />
             </MobileSource>
           </Map>
         );
@@ -58,7 +64,7 @@ export default function MobileDataLocationsCard({
 }
 
 MobileDataLocationsCard.propTypes = {
-  locationId: PropTypes.number.isRequired,
+  locationId: PropTypes.number,
   locationIds: PropTypes.arrayOf(PropTypes.number),
   bbox: PropTypes.arrayOf(PropTypes.number).isRequired,
   firstUpdated: PropTypes.string.isRequired,

--- a/app/assets/scripts/components/map/mobile-bounds-layer.js
+++ b/app/assets/scripts/components/map/mobile-bounds-layer.js
@@ -7,6 +7,7 @@ import { addPopover } from './map-interaction';
 
 export default function MobileBoundsLayer({
   locationId,
+  locationIds,
   activeParameter,
   map,
   sourceId,
@@ -53,11 +54,24 @@ export default function MobileBoundsLayer({
     };
   }, [locationId]);
 
+  useEffect(() => {
+    if (locationIds && map.getLayer(`mobile-bounds-${activeParameter}`))
+      map.setFilter(`mobile-bounds-${activeParameter}`, [
+        'in',
+        ['get', 'locationId'],
+        ['literal', locationIds],
+      ]);
+    return () => {
+      map.setFilter(`mobile-bounds-${activeParameter}`, null);
+    };
+  }, [locationIds]);
+
   return null;
 }
 
 MobileBoundsLayer.propTypes = {
   locationId: PropTypes.number,
+  locationIds: PropTypes.arrayOf(PropTypes.number),
   activeParameter: PropTypes.number,
   map: PropTypes.object,
   sourceId: PropTypes.string,

--- a/app/assets/scripts/components/map/mobile-points-layer.js
+++ b/app/assets/scripts/components/map/mobile-points-layer.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-export default function MobilePointsLayer({ map, sourceId }) {
+export default function MobilePointsLayer({ locationIds, map, sourceId }) {
   useEffect(() => {
     map.addLayer({
       id: 'mobile-points',
@@ -19,10 +19,23 @@ export default function MobilePointsLayer({ map, sourceId }) {
     };
   }, []);
 
+  useEffect(() => {
+    if (locationIds && map.getLayer('mobile-points'))
+      map.setFilter('mobile-points', [
+        'in',
+        ['get', 'locationId'],
+        ['literal', locationIds],
+      ]);
+    return () => {
+      map.setFilter('mobile-points', null);
+    };
+  }, [locationIds]);
+
   return null;
 }
 
 MobilePointsLayer.propTypes = {
+  locationIds: PropTypes.arrayOf(PropTypes.number),
   map: PropTypes.object,
   sourceId: PropTypes.string,
 };


### PR DESCRIPTION
This is applying a filter to the layers. 

Note that for individual locations we have a filter on the endpoint in place. Adding a way to filter the source tiles to the backend might help with performance?