### PR TITLE
Add check for locationIds

### DIFF
--- a/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
+++ b/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
@@ -30,7 +30,7 @@ export default function MobileDataLocationsCard({
         </CardHeader>
       )}
       renderBody={() => {
-        if (locationIds.length > 15) {
+        if (locationIds?.length > 15) {
           return (
             <ErrorMessage
               isShowingDiagnosis={false}


### PR DESCRIPTION
Mobile location pages were crashing. This is a quick fix, not sure if this param should actually be passed somewhere? @AliceR 