### PR TITLE
Remove parameters from tiles request

### DIFF
--- a/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
+++ b/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
@@ -19,8 +19,6 @@ export default function MobileDataLocationsCard({
   locationId,
   locationIds,
   bbox,
-  firstUpdated,
-  lastUpdated,
 }) {
   return (
     <Card
@@ -42,11 +40,7 @@ export default function MobileDataLocationsCard({
         }
         return (
           <Map bbox={bbox}>
-            <MobileSource
-              locationId={locationId}
-              firstUpdated={firstUpdated}
-              lastUpdated={lastUpdated}
-            >
+            <MobileSource>
               <MobileBoundsLayer
                 locationId={locationId}
                 locationIds={locationIds}

--- a/app/assets/scripts/components/map/mobile-bounds-layer.js
+++ b/app/assets/scripts/components/map/mobile-bounds-layer.js
@@ -50,7 +50,8 @@ export default function MobileBoundsLayer({
         locationId,
       ]);
     return () => {
-      map.setFilter(`mobile-bounds-${activeParameter}`, null);
+      if (map.getLayer(`mobile-bounds-${activeParameter}`))
+        map.setFilter(`mobile-bounds-${activeParameter}`, null);
     };
   }, [locationId]);
 
@@ -62,7 +63,8 @@ export default function MobileBoundsLayer({
         ['literal', locationIds],
       ]);
     return () => {
-      map.setFilter(`mobile-bounds-${activeParameter}`, null);
+      if (map.getLayer(`mobile-bounds-${activeParameter}`))
+        map.setFilter(`mobile-bounds-${activeParameter}`, null);
     };
   }, [locationIds]);
 

--- a/app/assets/scripts/components/map/mobile-points-layer.js
+++ b/app/assets/scripts/components/map/mobile-points-layer.js
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-export default function MobilePointsLayer({ locationIds, map, sourceId }) {
+export default function MobilePointsLayer({
+  locationId,
+  locationIds,
+  map,
+  sourceId,
+}) {
   useEffect(() => {
     map.addLayer({
       id: 'mobile-points',
@@ -20,6 +25,14 @@ export default function MobilePointsLayer({ locationIds, map, sourceId }) {
   }, []);
 
   useEffect(() => {
+    if (locationId && map.getLayer('mobile-points'))
+      map.setFilter('mobile-points', ['==', 'locationId', locationId]);
+    return () => {
+      if (map.getLayer('mobile-points')) map.setFilter('mobile-points', null);
+    };
+  }, [locationId]);
+
+  useEffect(() => {
     if (locationIds && map.getLayer('mobile-points'))
       map.setFilter('mobile-points', [
         'in',
@@ -27,7 +40,7 @@ export default function MobilePointsLayer({ locationIds, map, sourceId }) {
         ['literal', locationIds],
       ]);
     return () => {
-      map.setFilter('mobile-points', null);
+      if (map.getLayer('mobile-points')) map.setFilter('mobile-points', null);
     };
   }, [locationIds]);
 

--- a/app/assets/scripts/components/map/mobile-source.js
+++ b/app/assets/scripts/components/map/mobile-source.js
@@ -1,30 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
-import moment from 'moment';
+
 import config from '../../config';
 
-export default function MobileSource({
-  activeParameter,
-  locationId,
-  firstUpdated,
-  lastUpdated,
-  map,
-  children,
-}) {
+export default function MobileSource({ activeParameter, map, children }) {
   const [sourceId, setSourceId] = useState(null);
 
   useEffect(() => {
     if (!map.getSource(`mobile-source-${activeParameter}`)) {
       const query = {
         parameter: activeParameter,
-        location: locationId,
-        dateFrom: firstUpdated
-          ? moment(firstUpdated).subtract(1, 'd').format('YYYY-MM-DD')
-          : null,
-        dateTo: lastUpdated
-          ? moment(lastUpdated).add(1, 'd').format('YYYY-MM-DD')
-          : null,
       };
 
       map.addSource(`mobile-source-${activeParameter}`, {
@@ -50,7 +36,7 @@ export default function MobileSource({
     return () => {
       setSourceId(null);
     };
-  }, [activeParameter]); // activeParameter is the only prop that could update without unmounting the component
+  }, [activeParameter]);
 
   return (
     <>
@@ -68,9 +54,6 @@ export default function MobileSource({
 
 MobileSource.propTypes = {
   activeParameter: PropTypes.number,
-  locationId: PropTypes.number,
-  firstUpdated: PropTypes.string,
-  lastUpdated: PropTypes.string,
   map: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.element,


### PR DESCRIPTION
to benefit from the new server side caching. We can filter on the layers instead.