### PR TITLE
Connect mobile data to time selection

### DIFF
--- a/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
+++ b/app/assets/scripts/components/dashboard/mobile-data-locations-card.js
@@ -19,6 +19,7 @@ export default function MobileDataLocationsCard({
   locationId,
   locationIds,
   bbox,
+  dateRange,
 }) {
   return (
     <Card
@@ -48,6 +49,7 @@ export default function MobileDataLocationsCard({
               <MobilePointsLayer
                 locationId={locationId}
                 locationIds={locationIds}
+                dateRange={dateRange}
               />
             </MobileSource>
           </Map>
@@ -61,6 +63,8 @@ MobileDataLocationsCard.propTypes = {
   locationId: PropTypes.number,
   locationIds: PropTypes.arrayOf(PropTypes.number),
   bbox: PropTypes.arrayOf(PropTypes.number).isRequired,
-  firstUpdated: PropTypes.string.isRequired,
-  lastUpdated: PropTypes.string.isRequired,
+  dateRange: PropTypes.shape({
+    start: PropTypes.string.isRequired,
+    end: PropTypes.string.isRequired,
+  }),
 };

--- a/app/assets/scripts/components/map/mobile-points-layer.js
+++ b/app/assets/scripts/components/map/mobile-points-layer.js
@@ -1,12 +1,26 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import mapbox from 'mapbox-gl';
 
 export default function MobilePointsLayer({
   locationId,
   locationIds,
+  dateRange,
   map,
   sourceId,
 }) {
+  const colorExpression = [
+    'case',
+    [
+      'all',
+      ['has', 'lastUpdated'],
+      ['>=', ['get', 'lastUpdated'], ['literal', dateRange.start]],
+      ['<=', ['get', 'lastUpdated'], ['literal', dateRange.end]],
+    ],
+    '#198CFF',
+    '#555555',
+  ];
+
   useEffect(() => {
     map.addLayer({
       id: 'mobile-points',
@@ -14,15 +28,25 @@ export default function MobilePointsLayer({
       'source-layer': 'default',
       type: 'circle',
       paint: {
-        'circle-color': '#198CFF',
+        'circle-color': colorExpression,
         'circle-radius': 5,
         'circle-opacity': 0.6,
       },
     });
+
+    //  DEBUGGING HELPER: shows properties on hover
+    if (process.env.DS_ENV === 'development') {
+      displayProperties(map);
+    }
+
     return () => {
       if (map.getLayer('mobile-points')) map.removeLayer('mobile-points');
     };
   }, []);
+
+  useEffect(() => {
+    map.setPaintProperty('mobile-points', 'circle-color', colorExpression);
+  }, [dateRange]);
 
   useEffect(() => {
     if (locationId && map.getLayer('mobile-points'))
@@ -51,4 +75,36 @@ MobilePointsLayer.propTypes = {
   locationIds: PropTypes.arrayOf(PropTypes.number),
   map: PropTypes.object,
   sourceId: PropTypes.string,
+  dateRange: PropTypes.shape({
+    start: PropTypes.string.isRequired,
+    end: PropTypes.string.isRequired,
+  }).isRequired,
 };
+
+function displayProperties(map) {
+  var popup = new mapbox.Popup({
+    closeButton: false,
+    closeOnClick: false,
+  });
+
+  map.on('mouseenter', 'mobile-points', function (e) {
+    map.getCanvas().style.cursor = 'pointer';
+
+    var coordinates = e.features[0].geometry.coordinates.slice();
+    var description = JSON.stringify(e.features[0].properties);
+
+    // Ensure that if the map is zoomed out such that multiple
+    // copies of the feature are visible, the popup appears
+    // over the copy being pointed to.
+    while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+      coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+    }
+
+    popup.setLngLat(coordinates).setHTML(description).addTo(map);
+  });
+
+  map.on('mouseleave', 'mobile-points', function () {
+    map.getCanvas().style.cursor = '';
+    popup.remove();
+  });
+}

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import qs from 'qs';
+import moment from 'moment';
 
 import { openDownloadModal as openDownloadModalAction } from '../../actions/action-creators';
 import config from '../../config';
@@ -199,6 +200,27 @@ function Location({ location, history, match, openDownloadModal }) {
               bbox={data.bounds}
               firstUpdated={data.firstUpdated}
               lastUpdated={data.lastUpdated}
+              dateRange={
+                dateRange
+                  ? {
+                      start: moment(dateRange)
+                        .startOf(
+                          dateRange.split('/').length === 2 ? 'month' : 'day'
+                        )
+                        .utc(true)
+                        .format(),
+                      end: moment(dateRange)
+                        .endOf(
+                          dateRange.split('/').length === 2 ? 'month' : 'day'
+                        )
+                        .utc(true)
+                        .format(),
+                    }
+                  : {
+                      start: data.firstUpdated,
+                      end: data.lastUpdated,
+                    }
+              }
             />
           )}
           <TemporalCoverageCard

--- a/app/assets/scripts/views/project/dashboard.js
+++ b/app/assets/scripts/views/project/dashboard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 
 import DetailsCard from '../../components/dashboard/details-card';
 import LatestMeasurementsCard from '../../components/dashboard/lastest-measurements-card';
@@ -46,8 +47,28 @@ function Dashboard({
           locationId={locationIds.length === 1 ? locationIds[0] : null}
           locationIds={locationIds}
           bbox={bbox}
-          firstUpdated={projectDates.start}
-          lastUpdated={projectDates.end}
+          dateRange={
+            dateRange
+              ? {
+                  start: moment(dateRange)
+                    .startOf(
+                      dateRange.split('/').length === 2 ? 'month' : 'day'
+                    )
+                    .utc(true)
+                    .format(),
+                  end: moment(dateRange)
+                    .endOf(dateRange.split('/').length === 2 ? 'month' : 'day')
+                    .utc(true)
+                    .format(),
+                }
+              : {
+                  start: moment(projectDates.start)
+                    .startOf('day')
+                    .utc(true)
+                    .format(),
+                  end: moment(projectDates.end).endOf('day').utc(true).format(),
+                }
+          }
         />
       )}
       <MeasureandsCard


### PR DESCRIPTION
This displays the mobile data points within the selected time range as blue, and those not within in grey.

Note: the property 'lastUpdated' is missing on the tiles for the mobile points, hence currently all points are grey, always.