### PR TITLE
Add helper to debug map properties

### DIFF
--- a/app/assets/scripts/components/map/map-interaction.js
+++ b/app/assets/scripts/components/map/map-interaction.js
@@ -33,3 +33,31 @@ export function addPopover(map, layerId, locationId, activeParameter) {
 
   map.on('click', layerId, openPopup);
 }
+
+export function debugProperties(map, layerId) {
+  var popup = new mapbox.Popup({
+    closeButton: false,
+    closeOnClick: false,
+  });
+
+  map.on('mouseenter', layerId, function (e) {
+    map.getCanvas().style.cursor = 'pointer';
+
+    var coordinates = e.features[0].geometry.coordinates.slice();
+    var description = JSON.stringify(e.features[0].properties);
+
+    // Ensure that if the map is zoomed out such that multiple
+    // copies of the feature are visible, the popup appears
+    // over the copy being pointed to.
+    while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+      coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+    }
+
+    popup.setLngLat(coordinates).setHTML(description).addTo(map);
+  });
+
+  map.on('mouseleave', layerId, function () {
+    map.getCanvas().style.cursor = '';
+    popup.remove();
+  });
+}

--- a/app/assets/scripts/components/map/measurements-layer.js
+++ b/app/assets/scripts/components/map/measurements-layer.js
@@ -4,7 +4,7 @@ import { useRouteMatch } from 'react-router-dom';
 
 import { coloredSymbolSize, borderSymbolSize } from '../../utils/map-settings';
 import { getFillExpression } from '../../utils/colors';
-import { addPopover } from './map-interaction';
+import { addPopover, debugProperties } from './map-interaction';
 import { square, circle } from './symbols';
 
 export default function MeasurementsLayer({
@@ -66,6 +66,11 @@ export default function MeasurementsLayer({
       match.params.id,
       activeParameter
     );
+
+    //  DEBUGGING HELPER: shows properties on hover
+    if (process.env.DS_ENV === 'development') {
+      debugProperties(map, `${activeParameter}-layer`);
+    }
 
     return () => {
       if (map.getLayer(`${activeParameter}-layer`))


### PR DESCRIPTION
While in development mode only, it shows a popup displaying the properties of that feature.
It was helpful for me when debugging - maybe it helps you, too.

For now, I added it only to the measurements layer. Can be added to any other layer with  `debugProperties(map, <layerId>);`