### PR TITLE
Set max zoom on fit bounds

### DIFF
--- a/app/assets/scripts/components/map/map.js
+++ b/app/assets/scripts/components/map/map.js
@@ -33,7 +33,7 @@ export default function Map({ center, bbox, scrollZoomDisabled, children }) {
       if (center) {
         m.flyTo({ center, zoom: 15 });
       } else if (bbox) {
-        m.fitBounds(bbox, { padding: 20 });
+        m.fitBounds(bbox, { padding: 20, maxZoom: 18 });
       }
     });
 


### PR DESCRIPTION
avoid zooming in too far when there is only a tiny bbox (1 single measurement, or not at all moving).

E.g. http://localhost:3000/#/location/45152 - were the _accurate_ bbox provided by the locations object is way smaller than the generalized 30m bounds provided with the tiles 
