### PR TITLE
If page not found, redirect to home

### DIFF
--- a/app/assets/scripts/views/app.js
+++ b/app/assets/scripts/views/app.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withRouter, matchPath } from 'react-router-dom';
+import { withRouter, matchPath, Redirect } from 'react-router-dom';
 import c from 'classnames';
 
 import { closeDownloadModal as closeDownloadModalAction } from '../actions/action-creators';
@@ -13,12 +13,18 @@ import ModalDownload from '../components/modal-download/';
 function App(props) {
   const { children, location, downloadModal, closeDownloadModal } = props;
 
-  const pageClass = children.props.children.find(child => {
+  const matchedChild = children.props.children.find(child => {
     const match = matchPath(location.pathname, {
       path: child.props.path,
     });
     return match && match.isExact;
-  }).props.pageClass;
+  });
+
+  if (!matchedChild) {
+    return <Redirect to="/" />;
+  }
+
+  const pageClass = matchedChild.props.pageClass;
 
   return (
     <div className={c('page', pageClass)}>

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -60,6 +60,18 @@ function Location({ location, history, match, openDownloadModal }) {
         .then(
           json => {
             const dat = json.results[0];
+
+            if (!dat) {
+              setState(state => ({
+                ...state,
+                fetched: true,
+                fetching: false,
+                error: json,
+              }));
+
+              throw new Error('Bad response');
+            }
+
             setState(state => ({
               ...state,
               fetched: true,


### PR DESCRIPTION
I realize this project has no 404 page? Ideally, a 404 screen would be designed and implemented, but for now we can simply redirect to '/' (the home view), when the url doesn't match an expected path.

This happened with http://localhost:3000/#/locations/60544 (where a valid url would be http://localhost:3000/#/location/60544, note the s in locations)

Additionally, the location page would crash if the api returns no data for the location id. Now, we display an error message instead.