### PR TITLE
adds default date range - last 2 years

### DIFF
--- a/app/assets/scripts/components/dashboard/time-series-card.js
+++ b/app/assets/scripts/components/dashboard/time-series-card.js
@@ -36,6 +36,7 @@ const defaultState = {
 export default function TimeSeriesCard({
   locationId,
   projectId,
+  lastUpdated,
   parameters,
   prefetchedData,
   dateRange,
@@ -76,6 +77,10 @@ export default function TimeSeriesCard({
   const fetchData = () => {
     setState(state => ({ ...state, fetching: true, error: null }));
 
+    // get date 2 years prior to last updated
+    const defaultStartDate = new Date();
+    defaultStartDate.setFullYear(new Date(lastUpdated).getFullYear() - 3);
+
     let query = {
       parameter: activeTab.id,
       temporal,
@@ -87,7 +92,10 @@ export default function TimeSeriesCard({
               ? new Date(year, month - 1, day + 1)
               : new Date(year, month, 0),
           }
-        : {}),
+        : {
+            date_from: defaultStartDate,
+            date_to: lastUpdated,
+          }),
     };
 
     if (locationId) {
@@ -183,6 +191,7 @@ TimeSeriesCard.propTypes = {
   titleInfo: PropTypes.string,
   locationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  lastUpdated: PropTypes.instanceOf(Date),
   prefetchedData: PropTypes.object,
   parameters: PropTypes.arrayOf(
     PropTypes.shape({

--- a/app/assets/scripts/components/dashboard/time-series-card.js
+++ b/app/assets/scripts/components/dashboard/time-series-card.js
@@ -78,7 +78,7 @@ export default function TimeSeriesCard({
     setState(state => ({ ...state, fetching: true, error: null }));
 
     // get date 2 years prior to last updated
-    const defaultStartDate = new Date();
+    let defaultStartDate = new Date();
     defaultStartDate.setFullYear(new Date(lastUpdated).getFullYear() - 3);
 
     let query = {

--- a/app/assets/scripts/components/dashboard/time-series-card.js
+++ b/app/assets/scripts/components/dashboard/time-series-card.js
@@ -79,11 +79,12 @@ export default function TimeSeriesCard({
 
     // get date 2 years prior to last updated
     let defaultStartDate = new Date();
-    defaultStartDate.setFullYear(new Date(lastUpdated).getFullYear() - 3);
+    defaultStartDate.setFullYear(new Date(lastUpdated).getFullYear() - 2);
 
     let query = {
       parameter: activeTab.id,
       temporal,
+      limit: 10000,
       ...(dateRange
         ? {
             // In user space, month is 1 indexed

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -186,6 +186,7 @@ function Location({ location, history, match, openDownloadModal }) {
           <SourcesCard sources={data.sources} />
           <TimeSeriesCard
             locationId={data.id}
+            lastUpdated={data.lastUpdated}
             parameters={data.parameters}
             xUnit="day"
             dateRange={dateRange}

--- a/app/assets/scripts/views/project/dashboard.js
+++ b/app/assets/scripts/views/project/dashboard.js
@@ -36,6 +36,7 @@ function Dashboard({
       {!isAnalysis && (
         <TimeSeriesCard
           projectId={projectId}
+          lastUpdated={projectDates.end}
           parameters={projectParams}
           prefetchedData={timeseriesAverages}
           dateRange={dateRange}


### PR DESCRIPTION
addresses #678
good example to test `/location/21`
- adds a 2 year date range default on time series average request.
- increases limit to 1000

**Unresolved: We are not getting averages for the whole collection period from the backend. 
- project ex: 2 year lifespan only returns 1 year of data 

https://u50g7n0cbj.execute-api.us-east-1.amazonaws.com/v2/averages?temporal=moy&parameter=co2&spatial=project&project=richmond_beaco2n

- location ex: 6 year lifespan only returns 2 years of data
https://u50g7n0cbj.execute-api.us-east-1.amazonaws.com/v2/averages?parameter=pm25&temporal=day&location=21&spatial=location