### PR TITLE
Parameters table

### DIFF
--- a/app/assets/scripts/components/dashboard/parameters-card.js
+++ b/app/assets/scripts/components/dashboard/parameters-card.js
@@ -37,6 +37,7 @@ const tableHeaders = [
 export default function ParametersCard({
   parameters,
   locationId,
+  projectId,
   dateRange,
   titleInfo,
 }) {
@@ -80,8 +81,6 @@ export default function ParametersCard({
     };
 
     let query = {
-      location: locationId,
-      spatial: 'location',
       temporal,
       limit: 1000,
       ...(dateRange
@@ -95,6 +94,12 @@ export default function ParametersCard({
           }
         : null),
     };
+
+    if (locationId) {
+      query = { ...query, location: locationId, spatial: 'location' };
+    } else if (projectId) {
+      query = { ...query, project: projectId, spatial: 'project' };
+    }
 
     fetch(`${config.api}/averages?${qs.stringify(query, { skipNulls: true })}`)
       .then(response => {
@@ -149,7 +154,8 @@ export default function ParametersCard({
 
 ParametersCard.propTypes = {
   titleInfo: PropTypes.string.isRequired,
-  locationId: PropTypes.number.isRequired,
+  locationId: PropTypes.number,
+  projectId: PropTypes.number,
   dateRange: PropTypes.string,
   parameters: PropTypes.arrayOf(
     PropTypes.shape({

--- a/app/assets/scripts/components/dashboard/parameters-card.js
+++ b/app/assets/scripts/components/dashboard/parameters-card.js
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { PropTypes as T } from 'prop-types';
+import qs from 'qs';
+import datefns from 'date-fns';
 
+import config from '../../config';
+import LoadingMessage from '../loading-message';
+import ErrorMessage from '../error-message';
 import Card from '../card';
 import Table from '../table';
 import { shortenLargeNumber, round } from '../../utils/format';
@@ -29,13 +34,95 @@ const tableHeaders = [
   },
 ];
 
-export default function ParametersCard({ parameters, titleInfo }) {
-  const rows = parameters.map(p => ({
-    parameter: p.displayName,
-    avg: p.average,
-    count: p.count,
-    unit: p.unit,
-  }));
+export default function ParametersCard({
+  parameters,
+  locationId,
+  dateRange,
+  titleInfo,
+}) {
+  const defaultState = {
+    fetched: false,
+    fetching: false,
+    error: null,
+    data: parameters,
+  };
+  // eslint-disable-next-line no-unused-vars
+  const [{ fetched, fetching, error, data }, setState] = useState(defaultState);
+
+  // eslint-disable-next-line no-unused-vars
+  const [year, month, day] = (dateRange ? dateRange.split('/') : []).map(
+    Number
+  );
+
+  // If lifetime, use day. Else hour
+  const temporal = day ? 'day' : 'month';
+
+  useEffect(() => {
+    if (dateRange) fetchData(); // else use summary data provided by location itself
+
+    return () => {
+      setState(defaultState);
+    };
+  }, [dateRange]);
+
+  const fetchData = () => {
+    setState(state => ({ ...state, fetching: true, error: null }));
+
+    const formatDate = (dateStr, dateFunc) => {
+      let d = datefns.format(dateFunc(dateStr), 'YYYY-MM-DDTHH:mm:ss.SSS');
+      /* The browser will treat dates as if they are in the users local time zone.
+       * The backend expects time zone to be UTC
+       * to compensate, treat the date as if it is already UTC. AKA we are NOT converting to UTC, just treating the date as such.
+       * */
+
+      d = `${d}Z`;
+      return d;
+    };
+
+    let query = {
+      location: locationId,
+      spatial: 'location',
+      temporal,
+      limit: 1000,
+      ...(dateRange
+        ? {
+            date_from: day
+              ? formatDate(dateRange, datefns.startOfDay)
+              : formatDate(dateRange, datefns.startOfMonth),
+            date_to: day
+              ? formatDate(dateRange, datefns.endOfDay)
+              : formatDate(dateRange, datefns.endOfMonth),
+          }
+        : null),
+    };
+
+    fetch(`${config.api}/averages?${qs.stringify(query, { skipNulls: true })}`)
+      .then(response => {
+        if (response.status >= 400) {
+          throw new Error('Bad response');
+        }
+        return response.json();
+      })
+      .then(
+        json => {
+          setState(state => ({
+            ...state,
+            fetched: true,
+            fetching: false,
+            data: json.results,
+          }));
+        },
+        e => {
+          console.log('e', e);
+          setState(state => ({
+            ...state,
+            fetched: true,
+            fetching: false,
+            error: e,
+          }));
+        }
+      );
+  };
 
   return (
     <Card
@@ -43,7 +130,17 @@ export default function ParametersCard({ parameters, titleInfo }) {
       className="card--parameter"
       title="Parameters"
       renderBody={() => {
-        return <Table headers={tableHeaders} rows={rows} />;
+        if (fetching) return <LoadingMessage />;
+        if (data && data.length) {
+          const rows = data.map(p => ({
+            parameter: p.displayName,
+            avg: p.average,
+            count: p.measurement_count || p.count,
+            unit: p.unit,
+          }));
+          return <Table headers={tableHeaders} rows={rows} />;
+        }
+        return <ErrorMessage instructions="Please try a different time" />;
       }}
       titleInfo={titleInfo}
     />

--- a/app/assets/scripts/components/dashboard/parameters-card.js
+++ b/app/assets/scripts/components/dashboard/parameters-card.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { PropTypes as T } from 'prop-types';
+import PropTypes from 'prop-types';
 import qs from 'qs';
 import datefns from 'date-fns';
 
@@ -148,12 +148,14 @@ export default function ParametersCard({
 }
 
 ParametersCard.propTypes = {
-  titleInfo: T.string,
-  parameters: T.arrayOf(
-    T.shape({
-      parameter: T.string.isRequired,
-      count: T.number.isRequired,
-      average: T.number.isRequired,
-    })
-  ),
+  titleInfo: PropTypes.string.isRequired,
+  locationId: PropTypes.number.isRequired,
+  dateRange: PropTypes.string,
+  parameters: PropTypes.arrayOf(
+    PropTypes.shape({
+      parameter: PropTypes.string.isRequired,
+      count: PropTypes.number.isRequired,
+      average: PropTypes.number.isRequired,
+    }).isRequired
+  ).isRequired,
 };

--- a/app/assets/scripts/components/dashboard/parameters-card.js
+++ b/app/assets/scripts/components/dashboard/parameters-card.js
@@ -29,13 +29,7 @@ const tableHeaders = [
   },
 ];
 
-/*  TODO This function currently just extracts the first data available for each pollutant
- *  openAQ api returns all available dates averages, or those within a specified date range.
- *  The desired data in this card needs some clarification. should it be the most recent day?
- *  User specified day? date range? etc
- */
-
-export default function MeasureandsCard({ parameters, titleInfo }) {
+export default function ParametersCard({ parameters, titleInfo }) {
   const rows = parameters.map(p => ({
     parameter: p.displayName,
     avg: p.average,
@@ -45,8 +39,8 @@ export default function MeasureandsCard({ parameters, titleInfo }) {
 
   return (
     <Card
-      id="measurand"
-      className="card--measurand"
+      id="parameter"
+      className="card--parameter"
       title="Parameters"
       renderBody={() => {
         return <Table headers={tableHeaders} rows={rows} />;
@@ -56,7 +50,7 @@ export default function MeasureandsCard({ parameters, titleInfo }) {
   );
 }
 
-MeasureandsCard.propTypes = {
+ParametersCard.propTypes = {
   titleInfo: T.string,
   parameters: T.arrayOf(
     T.shape({

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -228,6 +228,8 @@ function Location({ location, history, match, openDownloadModal }) {
             />
           )}
           <ParametersCard
+            locationId={data.id}
+            dateRange={dateRange}
             parameters={data.parameters}
             titleInfo={
               'The average of all values and total number of measurements for each pollutant during the chosen time window.'

--- a/app/assets/scripts/views/location/location.js
+++ b/app/assets/scripts/views/location/location.js
@@ -12,7 +12,7 @@ import DetailsCard from '../../components/dashboard/details-card';
 import NearbyLocations from './nearby-locations';
 import LatestMeasurementsCard from '../../components/dashboard/lastest-measurements-card';
 import SourcesCard from '../../components/dashboard/sources-card';
-import MeasureandsCard from '../../components/dashboard/measurands-card';
+import ParametersCard from '../../components/dashboard/parameters-card';
 import TemporalCoverageCard from '../../components/dashboard/temporal-coverage-card';
 import TimeSeriesCard from '../../components/dashboard/time-series-card';
 import MobileDataLocationsCard from '../../components/dashboard/mobile-data-locations-card';
@@ -227,7 +227,7 @@ function Location({ location, history, match, openDownloadModal }) {
               isMobile={data.isMobile}
             />
           )}
-          <MeasureandsCard
+          <ParametersCard
             parameters={data.parameters}
             titleInfo={
               'The average of all values and total number of measurements for each pollutant during the chosen time window.'

--- a/app/assets/scripts/views/project/dashboard.js
+++ b/app/assets/scripts/views/project/dashboard.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import DetailsCard from '../../components/dashboard/details-card';
 import LatestMeasurementsCard from '../../components/dashboard/lastest-measurements-card';
 import SourcesCard from '../../components/dashboard/sources-card';
-import MeasureandsCard from '../../components/dashboard/measurands-card';
+import ParametersCard from '../../components/dashboard/parameters-card';
 import TemporalCoverageCard from '../../components/dashboard/temporal-coverage-card';
 import TimeSeriesCard from '../../components/dashboard/time-series-card';
 import MobileDataLocationsCard from '../../components/dashboard/mobile-data-locations-card';
@@ -55,14 +55,6 @@ function Dashboard({
         />
       )}
       {!isAnalysis && (
-        <MeasureandsCard
-          parameters={projectParams}
-          titleInfo={
-            "The average of all values and total number of measurements for the available pollutants during the chosen time window and for the selected locations. Keep in mind that not all locations may report the same pollutants. What are we doing when the locations aren't reporting the same pollutants?"
-          }
-        />
-      )}
-      {!isAnalysis && (
         <TemporalCoverageCard
           parameters={projectParams}
           dateRange={dateRange}
@@ -70,6 +62,16 @@ function Dashboard({
           id={projectName}
           titleInfo={
             'The average number of measurements for each pollutant by hour, day, or month at the selected locations. If a parameter is not present at one location in the dataset it will be omitted from the average. In some views a window may be turned off if that view is not applicable to the selected time window.'
+          }
+        />
+      )}
+      {!isAnalysis && (
+        <ParametersCard
+          parameters={projectParams}
+          dateRange={dateRange}
+          projectId={projectId}
+          titleInfo={
+            "The average of all values and total number of measurements for the available pollutants during the chosen time window and for the selected locations. Keep in mind that not all locations may report the same pollutants. What are we doing when the locations aren't reporting the same pollutants?"
           }
         />
       )}


### PR DESCRIPTION
Rename the measurands card to `parameters card` in order to reflect the new naming convention. 

If there is a date range selected, fetch the data for the parameters table from /averages instead of using the summary provided by /locations:id.

Close #717 