### PR TITLE
fixed "Correlation" spelling typo

### DIFF
--- a/app/assets/scripts/views/compare/compare-statistics.js
+++ b/app/assets/scripts/views/compare/compare-statistics.js
@@ -233,7 +233,7 @@ export default function CompareStatistics(props) {
                   )}
                 </p>
                 <strong>
-                  <p>Correlelation factor</p>
+                  <p>Correlation factor</p>
                 </strong>
                 <p>
                   {chartStats['leastSquares'].r !== undefined ? (


### PR DESCRIPTION
Hello! I have fixed the spelling typo you mentioned in the compare-statistics.js file. I also poked around in the other files to see if the others were correct and they seem fine!!

[Issue Link](https://github.com/openaq/openaq.org/issues/760)

All the best,

Andre 